### PR TITLE
Discord message, transfer failure, account name not shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 ## What it does:
 - this PowerShell script continuously transfers a percentage of profits automatically on a Binance Futures account, from Futures to Spot wallet, at a predefined interval.
 - if the following conditions are true:
-  - Currently used margin is less than the defined maximum (marginUsedPercentCurr < maxMarginUsedPercent)
-  - The the remaining balance after the trasfer is more than the defined minimum remaining balance (($totalBalance - $percentsOfProfit/100 * $profit) is > minRemainingBalance)
+  - Current used margin (open orders are taken into account here) is less than the defined maximum (marginUsedPercentMax < maxMarginUsedPercent from the json file)
+  - The remaining balance after the transfer is more than the defined minimum remaining balance (($totalBalance - $percentsOfProfit/100 * $profit) is > minRemainingBalance)
   - profit in the past X hours is positive.
 - checks for transfers within the past X hours when script starts, and doesn't perform a transfer if found any.
 - transfers the defined percentage of the profit ($percentsOfProfit * $profit) to Spot and sends Discord message.
@@ -23,9 +23,9 @@
 ## Instructions:
 - drop the script file and the json settings file into the same folder with your bot.
 - define the following in autoTransfer.json file
-  - **profitPercent**: the percentage of the profit of the past X hours you want transferred
+  - **profitPercent**: the percentage of the profit of the past X hours you want transferred.
   - **minRemainingBalance**: minimum remaining balance after the transfer.
-  - **maxMarginUsedPercent**: maximum used margin above which transfers should not occur.
+  - **maxMarginUsedPercent**: maximum used margin above which transfers should not occur (this includes the open orders).
   - **hours**: the period in hours of how often to perform transfers.
   - **proxy**: (optional) IP proxy and port to use (example "http://25.12.124.35:2763"). Leave blank if no proxy used (""). Get proxy IPs [here](https://www.webshare.io/?referral_code=wn3nlqpeqog7).
 - submit any issues or enhancement ideas on the [Issues](https://github.com/daisy613/autoTransfer/issues) page.

--- a/autoTransfer.ps1
+++ b/autoTransfer.ps1
@@ -176,7 +176,7 @@ while ($true) {
         $failureReasons = [string]$failureReasons
         write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] currentUsedMargin[$([math]::Round(($marginUsedPercentCurr), 1))%] $($settings.hours)hourProfit[$([math]::Round(($profit), 2))]" -color "Yellow"
         write-log -string "Conditions not fulfilled [$($failureReasons)]. Waiting 1 hr to retry..." -color "Yellow"
-        $message = "**TRANSFER**: FAILURE  **account**: $($settings.number)  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)hourProfit**: $([math]::Round(($profit), 2))"
+        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)hourProfit**: $([math]::Round(($profit), 2))"
         sendDiscord $settings.discord $message
         betterSleep 3600 "AutoTransfer $($version) (path: $($path)) - reattempting in 1hr (conditions not fulfilled)"
         ### Get current account info and profit

--- a/autoTransfer.ps1
+++ b/autoTransfer.ps1
@@ -154,7 +154,7 @@ while ($true) {
     $totalWalletBalance = [math]::Round(($accountInformation.totalWalletBalance), 2)
     try { $marginUsedPercentMax = (([decimal] $accountInformation.totalInitialMargin + [decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalWalletBalance) * 100 }
 	catch { $marginUsedPercentMax = 100 }
-	try { $marginUsedPercentCurr = (([decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalWalletBalance) * 100 }
+	try { $marginUsedPercentCurr = (([decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalMarginBalance) * 100 }
     catch { $marginUsedPercentCurr = 100 }
     $transferAmount = $settings.profitPercent * $($profit) / 100
     write-log -string "current settings: maxMarginUsedPercent[$($settings.maxMarginUsedPercent)] minRemainingBalance[$($settings.minRemainingBalance)] profitPercent[$($settings.profitPercent)] periodInHours[$($settings.hours)]" -color "Cyan"
@@ -188,7 +188,7 @@ while ($true) {
         $totalWalletBalance = [math]::Round(($accountInformation.totalWalletBalance), 2)
         try { $marginUsedPercentMax = (([decimal] $accountInformation.totalInitialMargin + [decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalWalletBalance) * 100 }
 		catch { $marginUsedPercentMax = 100 }
-		try { $marginUsedPercentCurr = (([decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalWalletBalance) * 100 }
+		try { $marginUsedPercentCurr = (([decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalMarginBalance) * 100 }
         catch { $marginUsedPercentCurr = 100 }
         $transferAmount = $settings.profitPercent * $($profit) / 100
     }

--- a/autoTransfer.ps1
+++ b/autoTransfer.ps1
@@ -178,7 +178,7 @@ while ($true) {
         $failureReasons = [string]$failureReasons
         write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] maxUsedMargin[$([math]::Round(($marginUsedPercentMax), 2))%] currentUsedMarginRatio[$([math]::Round(($marginRatioUsedPercentCurr), 2))%] $($settings.hours)-hourProfit[$([math]::Round(($profit), 2))]" -color "Yellow"
         write-log -string "Conditions not fulfilled [$($failureReasons)]. Waiting 1 hr to retry..." -color "Yellow"
-        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMarginRatio**: $([math]::Round(($marginRatioUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2)) **failureReason**: $($failureReasons)"
+        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMarginRatio**: $([math]::Round(($marginRatioUsedPercentCurr), 2))  **uPNL**: $([math]::Round(($accountInformation.totalUnrealizedProfit), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2)) **failureReason**: $($failureReasons)"
         sendDiscord $settings.discord $message
         betterSleep 3600 "AutoTransfer $($version) (path: $($path)) - reattempting in 1hr (conditions not fulfilled)"
         ### Get current account info and profit

--- a/autoTransfer.ps1
+++ b/autoTransfer.ps1
@@ -206,7 +206,7 @@ while ($true) {
     write-log -string "Transfer Successful!" -color "Green"
     write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] currUsedMargin[$([math]::Round($marginUsedPercentCurr,1))%] $($settings.hours)hourProfit[$([math]::Round(($profit), 2))] transferred[$([math]::Round(($transferAmount),2))] spotBalance[$($spotBalance)]" -color "Green"
     ### send discord message
-    $message = "**TRANSFER**: SUCCESS  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMargin**: $([math]::Round(($marginUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)hourProfit**: $([math]::Round(($profit), 2))  **transferred**: $([math]::Round(($transferAmount),2))  **spotBalance**: $($spotBalance)"
+    $message = "**TRANSFER**: SUCCESS  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMargin**: $([math]::Round(($marginUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2))  **transferred**: $([math]::Round(($transferAmount),2)) ($($settings.profitPercent)%)  **spotBalance**: $($spotBalance)"
     sendDiscord $settings.discord $message
     ### sleep for X $hours
     betterSleep ($settings.hours * 3600) "AutoTransfer $($version) (path: $($path))"

--- a/autoTransfer.ps1
+++ b/autoTransfer.ps1
@@ -154,8 +154,8 @@ while ($true) {
     $totalWalletBalance = [math]::Round(($accountInformation.totalWalletBalance), 2)
     try { $marginUsedPercentMax = (([decimal] $accountInformation.totalInitialMargin + [decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalWalletBalance) * 100 }
 	catch { $marginUsedPercentMax = 100 }
-	try { $marginUsedPercentCurr = (([decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalMarginBalance) * 100 }
-    catch { $marginUsedPercentCurr = 100 }
+	try { $marginRatioUsedPercentCurr = (([decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalMarginBalance) * 100 }
+    catch { $marginRatioUsedPercentCurr = 100 }
     $transferAmount = $settings.profitPercent * $($profit) / 100
     write-log -string "current settings: maxMarginUsedPercent[$($settings.maxMarginUsedPercent)] minRemainingBalance[$($settings.minRemainingBalance)] profitPercent[$($settings.profitPercent)] periodInHours[$($settings.hours)]" -color "Cyan"
     ### check if used margin percentage is less than defined, and total remaining balance is more than defined. if conditions don't apply, retry once an hour
@@ -176,9 +176,9 @@ while ($true) {
         # if ($failureReasons.length -gt 1) { $failureReasons = $failureReasons -join ' ,' }
         $ofs = ', '
         $failureReasons = [string]$failureReasons
-        write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] maxUsedMargin[$([math]::Round(($marginUsedPercentMax), 2))%] currentUsedMargin[$([math]::Round(($marginUsedPercentCurr), 2))%] $($settings.hours)-hourProfit[$([math]::Round(($profit), 2))]" -color "Yellow"
+        write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] maxUsedMargin[$([math]::Round(($marginUsedPercentMax), 2))%] currentUsedMarginRatio[$([math]::Round(($marginRatioUsedPercentCurr), 2))%] $($settings.hours)-hourProfit[$([math]::Round(($profit), 2))]" -color "Yellow"
         write-log -string "Conditions not fulfilled [$($failureReasons)]. Waiting 1 hr to retry..." -color "Yellow"
-        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMargin**: $([math]::Round(($marginUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2)) **failureReason**: $($failureReasons)"
+        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMarginRatio**: $([math]::Round(($marginRatioUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2)) **failureReason**: $($failureReasons)"
         sendDiscord $settings.discord $message
         betterSleep 3600 "AutoTransfer $($version) (path: $($path)) - reattempting in 1hr (conditions not fulfilled)"
         ### Get current account info and profit
@@ -188,8 +188,8 @@ while ($true) {
         $totalWalletBalance = [math]::Round(($accountInformation.totalWalletBalance), 2)
         try { $marginUsedPercentMax = (([decimal] $accountInformation.totalInitialMargin + [decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalWalletBalance) * 100 }
 		catch { $marginUsedPercentMax = 100 }
-		try { $marginUsedPercentCurr = (([decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalMarginBalance) * 100 }
-        catch { $marginUsedPercentCurr = 100 }
+		try { $marginRatioUsedPercentCurr = (([decimal] $accountInformation.totalMaintMargin) / $accountInformation.totalMarginBalance) * 100 }
+        catch { $marginRatioUsedPercentCurr = 100 }
         $transferAmount = $settings.profitPercent * $($profit) / 100
     }
     ### perform the transfer of ($percentsOfProfit * $profit) to Spot
@@ -204,9 +204,9 @@ while ($true) {
     }
     $spotBalance = [math]::Round(((getAccountSpt).balances | ? { $_.asset -eq "USDT" }).free, 2)
     write-log -string "Transfer Successful!" -color "Green"
-    write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] currUsedMargin[$([math]::Round($marginUsedPercentCurr,1))%] $($settings.hours)-hourProfit[$([math]::Round(($profit), 2))] transferred[$([math]::Round(($transferAmount),2))] spotBalance[$($spotBalance)]" -color "Green"
+    write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] currUsedMarginRatio[$([math]::Round($marginRatioUsedPercentCurr,1))%] $($settings.hours)-hourProfit[$([math]::Round(($profit), 2))] transferred[$([math]::Round(($transferAmount),2))] spotBalance[$($spotBalance)]" -color "Green"
     ### send discord message
-    $message = "**TRANSFER**: SUCCESS  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMargin**: $([math]::Round(($marginUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2))  **transferred**: $([math]::Round(($transferAmount),2)) ($($settings.profitPercent)%)  **spotBalance**: $($spotBalance)"
+    $message = "**TRANSFER**: SUCCESS  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMarginRatio**: $([math]::Round(($marginRatioUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2))  **transferred**: $([math]::Round(($transferAmount),2)) ($($settings.profitPercent)%)  **spotBalance**: $($spotBalance)"
     sendDiscord $settings.discord $message
     ### sleep for X $hours
     betterSleep ($settings.hours * 3600) "AutoTransfer $($version) (path: $($path))"

--- a/autoTransfer.ps1
+++ b/autoTransfer.ps1
@@ -178,7 +178,7 @@ while ($true) {
         $failureReasons = [string]$failureReasons
         write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] maxUsedMargin[$([math]::Round(($marginUsedPercentMax), 2))%] currentUsedMargin[$([math]::Round(($marginUsedPercentCurr), 2))%] $($settings.hours)hourProfit[$([math]::Round(($profit), 2))]" -color "Yellow"
         write-log -string "Conditions not fulfilled [$($failureReasons)]. Waiting 1 hr to retry..." -color "Yellow"
-        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMargin**: $([math]::Round(($marginUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)hourProfit**: $([math]::Round(($profit), 2))"
+        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMargin**: $([math]::Round(($marginUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)hourProfit**: $([math]::Round(($profit), 2)) **failureReason**: $($failureReasons)"
         sendDiscord $settings.discord $message
         betterSleep 3600 "AutoTransfer $($version) (path: $($path)) - reattempting in 1hr (conditions not fulfilled)"
         ### Get current account info and profit

--- a/autoTransfer.ps1
+++ b/autoTransfer.ps1
@@ -162,11 +162,11 @@ while ($true) {
     while (($marginUsedPercentMax -gt $settings.maxMarginUsedPercent) -or ($settings.minRemainingBalance -gt ($totalWalletBalance - $transferAmount)) -or $profit -le 0) {
         $failureReasons = @()
         if ($marginUsedPercentMax -gt $settings.maxMarginUsedPercent) {
-            $reason = "MAX_MARGIN_EXCEEDED"
+            $reason = "MAX_MARGIN_EXCEEDED, threshold: $($settings.maxMarginUsedPercent)"
             $failureReasons += $reason
         }
         elseif ($settings.minRemainingBalance -gt ($totalWalletBalance - $transferAmount)) {
-            $reason = "MIN_BALANCE_EXCEEDED"
+            $reason = "MIN_BALANCE_EXCEEDED, threshold: $($settings.minRemainingBalance)"
             $failureReasons += $reason
         }
         elseif ($profit -le 0) {
@@ -176,9 +176,9 @@ while ($true) {
         # if ($failureReasons.length -gt 1) { $failureReasons = $failureReasons -join ' ,' }
         $ofs = ', '
         $failureReasons = [string]$failureReasons
-        write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] maxUsedMargin[$([math]::Round(($marginUsedPercentMax), 2))%] currentUsedMargin[$([math]::Round(($marginUsedPercentCurr), 2))%] $($settings.hours)hourProfit[$([math]::Round(($profit), 2))]" -color "Yellow"
+        write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] maxUsedMargin[$([math]::Round(($marginUsedPercentMax), 2))%] currentUsedMargin[$([math]::Round(($marginUsedPercentCurr), 2))%] $($settings.hours)-hourProfit[$([math]::Round(($profit), 2))]" -color "Yellow"
         write-log -string "Conditions not fulfilled [$($failureReasons)]. Waiting 1 hr to retry..." -color "Yellow"
-        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMargin**: $([math]::Round(($marginUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)hourProfit**: $([math]::Round(($profit), 2)) **failureReason**: $($failureReasons)"
+        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMargin**: $([math]::Round(($marginUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2)) **failureReason**: $($failureReasons)"
         sendDiscord $settings.discord $message
         betterSleep 3600 "AutoTransfer $($version) (path: $($path)) - reattempting in 1hr (conditions not fulfilled)"
         ### Get current account info and profit
@@ -204,7 +204,7 @@ while ($true) {
     }
     $spotBalance = [math]::Round(((getAccountSpt).balances | ? { $_.asset -eq "USDT" }).free, 2)
     write-log -string "Transfer Successful!" -color "Green"
-    write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] currUsedMargin[$([math]::Round($marginUsedPercentCurr,1))%] $($settings.hours)hourProfit[$([math]::Round(($profit), 2))] transferred[$([math]::Round(($transferAmount),2))] spotBalance[$($spotBalance)]" -color "Green"
+    write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] currUsedMargin[$([math]::Round($marginUsedPercentCurr,1))%] $($settings.hours)-hourProfit[$([math]::Round(($profit), 2))] transferred[$([math]::Round(($transferAmount),2))] spotBalance[$($spotBalance)]" -color "Green"
     ### send discord message
     $message = "**TRANSFER**: SUCCESS  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMargin**: $([math]::Round(($marginUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2))  **transferred**: $([math]::Round(($transferAmount),2)) ($($settings.profitPercent)%)  **spotBalance**: $($spotBalance)"
     sendDiscord $settings.discord $message

--- a/autoTransfer.ps1
+++ b/autoTransfer.ps1
@@ -178,7 +178,7 @@ while ($true) {
         $failureReasons = [string]$failureReasons
         write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] maxUsedMargin[$([math]::Round(($marginUsedPercentMax), 2))%] currentUsedMarginRatio[$([math]::Round(($marginRatioUsedPercentCurr), 2))%] $($settings.hours)-hourProfit[$([math]::Round(($profit), 2))]" -color "Yellow"
         write-log -string "Conditions not fulfilled [$($failureReasons)]. Waiting 1 hr to retry..." -color "Yellow"
-        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMarginRatio**: $([math]::Round(($marginRatioUsedPercentCurr), 2))  **uPNL**: $([math]::Round(($accountInformation.totalUnrealizedProfit), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2)) **failureReason**: $($failureReasons)"
+        $message = "**TRANSFER**: FAILURE  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMarginRatio**: $([math]::Round(($marginRatioUsedPercentCurr), 2))  **uPNL**: $([math]::Round(($accountInformation.totalUnrealizedProfit), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2))  **failureReason**: $($failureReasons)"
         sendDiscord $settings.discord $message
         betterSleep 3600 "AutoTransfer $($version) (path: $($path)) - reattempting in 1hr (conditions not fulfilled)"
         ### Get current account info and profit
@@ -206,7 +206,7 @@ while ($true) {
     write-log -string "Transfer Successful!" -color "Green"
     write-log -string "account[$($settings.name)] totalBalance[$($totalWalletBalance)] currUsedMarginRatio[$([math]::Round($marginRatioUsedPercentCurr,1))%] $($settings.hours)-hourProfit[$([math]::Round(($profit), 2))] transferred[$([math]::Round(($transferAmount),2))] spotBalance[$($spotBalance)]" -color "Green"
     ### send discord message
-    $message = "**TRANSFER**: SUCCESS  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMarginRatio**: $([math]::Round(($marginRatioUsedPercentCurr), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2))  **transferred**: $([math]::Round(($transferAmount),2)) ($($settings.profitPercent)%)  **spotBalance**: $($spotBalance)"
+    $message = "**TRANSFER**: SUCCESS  **account**: $($settings.name)  **maxUsedMargin**: $([math]::Round(($marginUsedPercentMax), 2))  **currentUsedMarginRatio**: $([math]::Round(($marginRatioUsedPercentCurr), 2))  **uPNL**: $([math]::Round(($accountInformation.totalUnrealizedProfit), 2))  **totalBalance**: $($totalWalletBalance)  **$($settings.hours)-hourProfit**: $([math]::Round(($profit), 2))  **transferred**: $([math]::Round(($transferAmount),2)) ($($settings.profitPercent)%)  **spotBalance**: $($spotBalance)"
     sendDiscord $settings.discord $message
     ### sleep for X $hours
     betterSleep ($settings.hours * 3600) "AutoTransfer $($version) (path: $($path))"


### PR DESCRIPTION
The account name was not displayed in the Discord message, in case of transfer failure.
This is a leftover from the multiple accounts feature deletion.